### PR TITLE
Upgrading to slack-scala-client 0.3.0 and dropping Scala 2.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ outside this list)
     ```
 4. Perform a release in selected Scala versions:
     ```
-    ./gradlew build publish -PscalaVersion=2.11.12
     ./gradlew build publish -PscalaVersion=2.12.12
     ./gradlew build publish -PscalaVersion=2.13.3
     ```

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ repositories {
 }
 
 dependencies {
-    compile "com.github.slack-scala-client:slack-scala-client_${scalaMajorVersion}:0.2.17"
+    compile "com.github.slack-scala-client:slack-scala-client_${scalaMajorVersion}:0.3.0"
     compile "com.typesafe.akka:akka-testkit_${scalaMajorVersion}:${akkaVersion}"
     compile "com.typesafe.akka:akka-stream_${scalaMajorVersion}:${akkaVersion}"
     compile "org.scalatest:scalatest_${scalaMajorVersion}:3.0.8"

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.configureondemand=true
 javaSourceVersion = 1.8
 javaTargetVersion = 1.8
 
-supportedScalaVersions = 2.11.12, 2.12.12, 2.13.3
+supportedScalaVersions = 2.12.12, 2.13.3
 defaultScalaVersion = 2.12.12
 akkaVersion = 2.5.32
 awsSdkVersion = 1.11.1017


### PR DESCRIPTION
Upgrading to https://github.com/slack-scala-client/slack-scala-client/releases/tag/v0.3.0

... which triggers removal of Scala 2.11 support, which I think we don't need anymore.

There are 3 akka-http warnings now, ignoring them for now. To be solved later :/