### PR TITLE
Revert "Bump license-gradle-plugin from 0.15.0 to 0.16.1"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.16.1"
+        classpath "gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.15.0"
         classpath "org.owasp:dependency-check-gradle:6.5.3"
         classpath "com.github.ben-manes:gradle-versions-plugin:0.42.0"
     }


### PR DESCRIPTION
Reverts SumoLogic-Labs/sumobot#95
because it causes:
```
* Where:
Build file '/Users/myuser/git/bot-sumobot/build.gradle' line: 31
* What went wrong:
A problem occurred evaluating root project 'sumobot'.
> java.lang.AbstractMethodError (no error message)
```
