### PR TITLE
Allowing the credentials to be specified somewhere else than sumobot.…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,7 @@ compileScala {
 
 application {
     mainClassName = 'com.sumologic.sumobot.Main'
+    applicationDefaultJvmArgs = ['-Dconfig.override_with_env_vars=true']
 }
 
 ext.gitCommitIdAbbrev = System.getenv('GIT_COMMIT_ID_ABBREV') ?: 'git rev-parse --verify --short=12 HEAD'.execute().text.trim()

--- a/src/main/scala/com/sumologic/sumobot/core/Bootstrap.scala
+++ b/src/main/scala/com/sumologic/sumobot/core/Bootstrap.scala
@@ -42,7 +42,11 @@ object Bootstrap {
     def readConfig: Config
   }
   case object FileConfigReader extends ConfigReader {
-    override def readConfig: Config = ConfigFactory.parseFile(new File(configFileLocation)).resolve()
+    override def readConfig: Config =
+      ConfigFactory
+        .parseFile(new File(configFileLocation))
+        .resolve()
+        .withFallback(ConfigFactory.systemEnvironmentOverrides())
   }
   case object ClasspathConfigReader extends ConfigReader {
     override def readConfig: Config = ConfigFactory.load(configFileLocation)


### PR DESCRIPTION
Allowing the credentials to be specified somewhere else than `sumobot.conf` - i.e. using environment variables like:
```
export CONFIG_FORCE_slack_api_token=$(cat /home/my/Secrets/slack.api.token)
```
