### PR TITLE
Passing Receptionist to each plugin

### DIFF
--- a/src/main/scala/com/sumologic/sumobot/core/HttpReceptionist.scala
+++ b/src/main/scala/com/sumologic/sumobot/core/HttpReceptionist.scala
@@ -48,7 +48,7 @@ class HttpReceptionist(brain: ActorRef) extends Actor with ActorLogging {
 
   override def receive: Receive = {
     case message@PluginAdded(plugin, _) =>
-      plugin ! InitializePlugin(HttpReceptionist.State, brain, pluginRegistry)
+      plugin ! InitializePlugin(HttpReceptionist.State, brain, pluginRegistry, self)
       pluginRegistry ! message
 
     case message@PluginRemoved(_) =>

--- a/src/test/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServerTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServerTest.scala
@@ -55,7 +55,7 @@ class SumoBotHttpServerTest
   private val brain = TestActorRef(Props[InMemoryBrain]())
   private val httpReceptionist = TestActorRef(new HttpReceptionist(brain))
 
-  private val pluginCollection = PluginsFromProps(Array(Props(classOf[Help]), Props(classOf[System])))
+  private val pluginCollection: PluginsFromProps = PluginsFromProps(Array(Props(classOf[Help]), Props(classOf[System])))
 
   override def beforeAll: Unit = {
     Bootstrap.receptionist = Some(httpReceptionist)

--- a/src/test/scala/com/sumologic/sumobot/plugins/advice/AdviceTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/plugins/advice/AdviceTest.scala
@@ -26,7 +26,7 @@ import scala.concurrent.duration._
 class AdviceTest extends BotPluginTestKit(ActorSystem("AdviceTest"))  {
 
   val adviceRef = system.actorOf(Props[Advice](), "advice")
-  adviceRef ! InitializePlugin(null, null, null)
+  adviceRef ! InitializePlugin(null, null, null, outgoingMessageProbe.testActor)
 
   "advice" should {
 

--- a/src/test/scala/com/sumologic/sumobot/plugins/alias/AliasTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/plugins/alias/AliasTest.scala
@@ -33,7 +33,7 @@ class AliasTest
 
   val aliasRef = system.actorOf(Props(classOf[Alias]), "alias")
   val brainRef = system.actorOf(Props(classOf[InMemoryBrain]), "brain")
-  aliasRef ! InitializePlugin(null, brainRef, null)
+  aliasRef ! InitializePlugin(null, brainRef, null, outgoingMessageProbe.testActor)
 
   "alias" should {
     "allow aliasing messages to the bot" in {

--- a/src/test/scala/com/sumologic/sumobot/plugins/help/HelpTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/plugins/help/HelpTest.scala
@@ -35,7 +35,7 @@ class HelpTest extends BotPluginTestKit(ActorSystem("HelpTest")) {
   reg ! PluginAdded(mock, "mock help")
   reg ! PluginAdded(helpRef, "help help")
 
-  helpRef ! InitializePlugin(null, null, reg)
+  helpRef ! InitializePlugin(null, null, reg, outgoingMessageProbe.testActor)
 
   val user = mockUser("123", "jshmoe")
 


### PR DESCRIPTION
WIP. For no apparent reason I thought it's cleaner to replace make the communication between the plugins and the receptionist more explicit.
I.e. let the plugins send directly to the receptionist instead of shouting loud in the open (`context.system.eventStream.publish`).

Somehow it fails for the http-receptionist tests. I fail to understand them and have hard time trying to fix them. I can only guess - the failing test doesn't reproduce the full bootstrap/init sequence, thus it doesn't go through the `InitializePlugin`