### PR TITLE
Removing ben names versions plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,6 @@ buildscript {
     dependencies {
         classpath "gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.16.1"
         classpath "org.owasp:dependency-check-gradle:8.0.1"
-        classpath "com.github.ben-manes:gradle-versions-plugin:0.44.0"
     }
 
     ext.akkaVersion = '2.6.20'
@@ -31,7 +30,6 @@ apply plugin: "application"
 apply plugin: "com.github.hierynomus.license"
 apply plugin: "signing"
 apply plugin: "org.owasp.dependencycheck"
-apply plugin: "com.github.ben-manes.versions"
 
 group = "com.sumologic.sumobot"
 description = "A Slack bot implemented in Akka"


### PR DESCRIPTION
**What**:
Removing the Ben Names Versions Gradle plugin

**Why**:
I don't think we use that any more. We are happy with @Dependabot
