### PR TITLE
Remove putAll usage

### DIFF
--- a/src/main/scala/com/sumologic/sumobot/brain/S3Brain.scala
+++ b/src/main/scala/com/sumologic/sumobot/brain/S3Brain.scala
@@ -79,7 +79,7 @@ class S3Brain(credentials: AWSCredentials,
     }
 
     val props = new Properties()
-    props.putAll(contents.asJava)
+    contents.foreach { case (k,v) => props.put(k,v) }
     val out = new ByteArrayOutputStream()
     props.store(out, "")
     out.flush()


### PR DESCRIPTION
**What**:
Minor refactoring.
Avoid the usage of `putAll` method.

**Why**:
To avoid the compilation error:
```
src/main/scala/com/sumologic/sumobot/brain/S3Brain.scala:82:11: ambiguous reference to overloaded definition,
both method putAll in class Properties of type (x$1: java.util.Map[_, _])Unit
and  method putAll in class Hashtable of type (x$1: java.util.Map[_ <: Object, _ <: Object])Unit
match argument types (java.util.Map[String,String])
one error found
```
using some Java versions.

Context: https://github.com/scala/bug/issues/10418