### PR TITLE
Removing excessive dependencies for Scala

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,8 +70,6 @@ dependencies {
         exclude group: "org.specs2", module: "specs2_${scalaMajorVersion}"
     }
     implementation "org.scala-lang:scala-compiler:${scalaMajorVersion}.${scalaMinorVersion}"
-    implementation "org.scala-lang:scalap:${scalaMajorVersion}.${scalaMinorVersion}"
-    implementation "org.scala-lang:scala-reflect:${scalaMajorVersion}.${scalaMinorVersion}"
     implementation "org.scala-lang.modules:scala-collection-compat_${scalaMajorVersion}:2.6.0"
 
     implementation "com.fasterxml.jackson.core:jackson-databind:${comFasterxmlJacksonVersion}"


### PR DESCRIPTION
**What**:
Removing excessive Scala lang dependencies

**Why**:
They were flagged when I tried to migrate to Scala 3 locally.
It seems like we don't need them in Scala 2 either.