### PR TITLE
SumoBot Start using EventsAPI as RTM Client is deprecated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,10 @@ dependencies {
     implementation "org.scalatestplus:junit-4-13_${scalaMajorVersion}:3.2.15.0"
     implementation "org.scalatestplus:mockito-4-6_${scalaMajorVersion}:3.2.15.0"
     implementation "org.mockito:mockito-core:4.11.0"
+
+    implementation 'com.slack.api:bolt-socket-mode:1.45.3'
+    implementation 'javax.websocket:javax.websocket-api:1.1'
+    implementation 'org.glassfish.tyrus.bundles:tyrus-standalone-client:1.20'
 }
 
 compileScala {

--- a/src/main/scala/com/sumologic/sumobot/core/EventsClient.scala
+++ b/src/main/scala/com/sumologic/sumobot/core/EventsClient.scala
@@ -29,15 +29,15 @@ class EventsClient private (appToken: String, appConfig: AppConfig) {
         val incoming = Message(
           event.getTs,
           event.getChannel,
-          Some(event.getUser),
+          Option(event.getUser),
           event.getText,
-          Some(event.getBotId),
+          Option(event.getBotId),
           None,
-          Some(event.getThreadTs),
-          Some(Option(event.getAttachments)
+          Option(event.getThreadTs),
+          Option(Option(event.getAttachments)
             .map(_.asScala.toSeq).getOrElse(Seq.empty)
             .asInstanceOf[Seq[slack.models.Attachment]]),
-          Some(event.getSubtype)
+          Option(event.getSubtype)
         )
         messageRouter ! incoming
       }

--- a/src/main/scala/com/sumologic/sumobot/core/EventsClient.scala
+++ b/src/main/scala/com/sumologic/sumobot/core/EventsClient.scala
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.sumologic.sumobot.core
 
 import akka.actor.ActorRef

--- a/src/main/scala/com/sumologic/sumobot/core/EventsClient.scala
+++ b/src/main/scala/com/sumologic/sumobot/core/EventsClient.scala
@@ -1,0 +1,59 @@
+package com.sumologic.sumobot.core
+
+import akka.actor.ActorRef
+import com.slack.api.bolt.handler.BoltEventHandler
+import slack.models.Message
+import com.slack.api.bolt.App
+import com.slack.api.bolt.AppConfig
+import com.slack.api.bolt.socket_mode.SocketModeApp
+import com.slack.api.model.event.MessageEvent
+import scala.jdk.CollectionConverters._
+
+
+object EventsClient {
+  def apply(appToken: String, botToken: String): EventsClient = {
+    val appConfig = AppConfig.builder.singleTeamBotToken(botToken).build
+    new EventsClient(appToken, appConfig)
+  }
+}
+
+class EventsClient private (appToken: String, appConfig: AppConfig) {
+  private val app = new App(appConfig)
+  private val socketModeApp = new SocketModeApp(appToken, app)
+
+  def addEventListener(messageRouter: ActorRef): Unit = {
+
+    val messageEventHandler : BoltEventHandler[MessageEvent] = (payload, context) => {
+      val event = payload.getEvent
+      if (event.getText != null && event.getUser != null) {
+        val incoming = Message(
+          event.getTs,
+          event.getChannel,
+          Some(event.getUser),
+          event.getText,
+          Some(event.getBotId),
+          None,
+          Some(event.getThreadTs),
+          Some(Option(event.getAttachments)
+            .map(_.asScala.toSeq).getOrElse(Seq.empty)
+            .asInstanceOf[Seq[slack.models.Attachment]]),
+          Some(event.getSubtype)
+        )
+        messageRouter ! incoming
+      }
+      context.ack()
+    }
+
+    app.event(classOf[MessageEvent], messageEventHandler)
+    socketModeApp.startAsync()
+  }
+
+  def destroy(): Unit = {
+    if(app != null) {
+      app.stop()
+    }
+    if(socketModeApp != null) {
+      socketModeApp.stop()
+    }
+  }
+}

--- a/src/main/scala/com/sumologic/sumobot/core/HttpReceptionist.scala
+++ b/src/main/scala/com/sumologic/sumobot/core/HttpReceptionist.scala
@@ -21,9 +21,7 @@ package com.sumologic.sumobot.core
 import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import com.sumologic.sumobot.core.model.PublicChannel
 import com.sumologic.sumobot.plugins.BotPlugin.{InitializePlugin, PluginAdded, PluginRemoved}
-import slack.api.RtmConnectState
-import slack.models.{Channel, Team, User}
-import slack.rtm.RtmState
+import slack.models.{Channel, User}
 
 import java.time.Instant
 
@@ -33,14 +31,7 @@ object HttpReceptionist {
   val DefaultSumoBotChannelId = DefaultChannel.id
   val DefaultSumoBotChannel = PublicChannel(DefaultChannel.id, DefaultChannel.name)
 
-  val DefaultBotUser = User("U0001SUMO", "sumobot-bot", None, None, None, None, None, None, None, None, None, None, None, None, None, None)
   val DefaultClientUser = User("U0002SUMO", "sumobot-client", None, None, None, None, None, None, None, None, None, None, None, None, None, None)
-
-  private[core] val StateUrl = ""
-  private[core] val StateTeam = Team("T0001SUMO", "Sumo Bot", "sumobot")
-
-  private[core] val StartState = RtmConnectState(true, StateUrl, DefaultBotUser, StateTeam)
-  private[core] val State = new RtmState(StartState)
 }
 
 class HttpReceptionist(brain: ActorRef) extends Actor with ActorLogging {
@@ -48,7 +39,7 @@ class HttpReceptionist(brain: ActorRef) extends Actor with ActorLogging {
 
   override def receive: Receive = {
     case message@PluginAdded(plugin, _) =>
-      plugin ! InitializePlugin(HttpReceptionist.State, brain, pluginRegistry)
+      plugin ! InitializePlugin(brain, pluginRegistry)
       pluginRegistry ! message
 
     case message@PluginRemoved(_) =>

--- a/src/main/scala/com/sumologic/sumobot/core/Receptionist.scala
+++ b/src/main/scala/com/sumologic/sumobot/core/Receptionist.scala
@@ -80,7 +80,7 @@ class Receptionist(eventsClient: EventsClient,
   // VisibleForTesting
   protected def fetchUsers(): Seq[User] = {
     // NOTE(mccartney, 2023-01-30): I couldn't get the syncClient to do the same, it failed with timeout(15s)
-    Await.result(asyncClient.listUsers(), atMost = Duration(1, TimeUnit.MINUTES))
+    Await.result(asyncClient.listUsers(), atMost = Duration(2, TimeUnit.MINUTES))
   }
 
   protected def getAuthInfo: AuthIdentity = {

--- a/src/main/scala/com/sumologic/sumobot/core/Receptionist.scala
+++ b/src/main/scala/com/sumologic/sumobot/core/Receptionist.scala
@@ -19,12 +19,10 @@
 package com.sumologic.sumobot.core
 
 import akka.actor._
-import com.sumologic.sumobot.core.Receptionist.{RtmStateRequest, RtmStateResponse}
 import com.sumologic.sumobot.core.model._
 import com.sumologic.sumobot.plugins.BotPlugin.{InitializePlugin, PluginAdded, PluginRemoved}
 import slack.api.{BlockingSlackApiClient, SlackApiClient}
 import slack.models.{ImOpened, Message, MessageChanged, ReactionAdded, ReactionItemMessage, User, Attachment => SAttachment}
-import slack.rtm.{RtmState, SlackRtmClient}
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.Await
@@ -33,27 +31,24 @@ import scala.concurrent.duration.Duration
 
 object Receptionist {
 
-  case class RtmStateRequest(sendTo: ActorRef)
-
-  case class RtmStateResponse(rtmState: RtmState)
-
-  def props(rtmClient: SlackRtmClient,
+  def props(eventsClient: EventsClient,
             syncClient: BlockingSlackApiClient,
             asyncClient: SlackApiClient,
             brain: ActorRef): Props =
-    Props(new Receptionist(rtmClient, syncClient, asyncClient, brain))
+    Props(new Receptionist(eventsClient, syncClient, asyncClient, brain))
 }
 
-class Receptionist(rtmClient: SlackRtmClient,
+class Receptionist(eventsClient: EventsClient,
                    syncClient: BlockingSlackApiClient,
                    asyncClient: SlackApiClient,
                    brain: ActorRef) extends Actor with ActorLogging {
 
   implicit val system = ActorSystem("slack")
 
-  private val selfId = rtmClient.state.self.id
-  private val selfName = rtmClient.state.self.name
-  rtmClient.addEventListener(self)
+  private val authResponse = syncClient.testAuth
+  private val selfId = authResponse.user_id
+  private val selfName = authResponse.user
+  eventsClient.addEventListener(self)
 
   private val atMention = """<@(\w+)>:(.*)""".r
   private val atMentionWithoutColon = """<@(\w+)>\s(.*)""".r
@@ -73,7 +68,6 @@ class Receptionist(rtmClient: SlackRtmClient,
       classOf[OutgoingMessageWithAttachments],
       classOf[OutgoingImage],
       classOf[OpenIM],
-      classOf[RtmStateRequest],
       classOf[ResponseInProgress],
       classOf[NewChannelTopic],
       classOf[SendIMByUserName]
@@ -91,12 +85,13 @@ class Receptionist(rtmClient: SlackRtmClient,
 
   override def postStop(): Unit = {
     context.system.eventStream.unsubscribe(self)
+    eventsClient.destroy()
   }
 
   override def receive: Receive = {
 
     case message@PluginAdded(plugin, _) =>
-      plugin ! InitializePlugin(rtmClient.state, brain, pluginRegistry)
+      plugin ! InitializePlugin(brain, pluginRegistry)
       pluginRegistry ! message
 
     case message@PluginRemoved(_) =>
@@ -104,7 +99,7 @@ class Receptionist(rtmClient: SlackRtmClient,
 
     case OutgoingMessage(channelId, text, threadTs) =>
       log.info(s"sending - $channelId: $text")
-      rtmClient.sendMessage(channelId, text, threadTs)
+      asyncClient.postChatMessage(channelId, text, threadTs = threadTs)
 
     case OutgoingMessageWithAttachments(channel, text, threadTs, attachments) =>
       log.info(s"sending - ${channel.name}: $text")
@@ -139,12 +134,6 @@ class Receptionist(rtmClient: SlackRtmClient,
       val message = messageChanged.message
       translateAndDispatch(messageChanged.channel, message.user.get, message.text, message.ts,
         attachments = message.attachments.getOrElse(Seq()))
-
-    case RtmStateRequest(sendTo) =>
-      sendTo ! RtmStateResponse(rtmClient.state)
-
-    case ResponseInProgress(channelId) =>
-      rtmClient.indicateTyping(channelId)
 
     case ReactionAdded(reaction, ReactionItemMessage(channel, ts), _, user, _) =>
       context.system.eventStream.publish(Reaction(reaction, channel, ts, user))

--- a/src/main/scala/com/sumologic/sumobot/core/model/Channels.scala
+++ b/src/main/scala/com/sumologic/sumobot/core/model/Channels.scala
@@ -19,7 +19,6 @@
 package com.sumologic.sumobot.core.model
 
 import slack.models.{Message, User}
-import slack.rtm.RtmState
 
 trait Channel {
   def id: String

--- a/src/main/scala/com/sumologic/sumobot/plugins/BotPlugin.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/BotPlugin.scala
@@ -28,7 +28,6 @@ import com.typesafe.config.Config
 import org.apache.http.HttpResponse
 import org.apache.http.client.methods.{HttpGet, HttpUriRequest}
 import slack.models.{Group, Im, User, Channel => ClientChannel}
-import slack.rtm.RtmState
 
 import java.net.URLEncoder
 import java.util.concurrent.{Executors, TimeoutException}
@@ -46,7 +45,7 @@ object BotPlugin {
 
   case class PluginRemoved(plugin: ActorRef)
 
-  case class InitializePlugin(state: RtmState, brain: ActorRef, pluginRegistry: ActorRef)
+  case class InitializePlugin(brain: ActorRef, pluginRegistry: ActorRef)
 
   def matchText(regex: String): Regex = ("(?i)(?s)" + regex).r
 }
@@ -58,8 +57,6 @@ abstract class BotPlugin
 
   type ReceiveIncomingMessage = PartialFunction[IncomingMessage, Unit]
   type ReceiveReaction = PartialFunction[Reaction, Unit]
-
-  protected var state: RtmState = _
 
   protected var brain: ActorRef = _
 
@@ -200,8 +197,7 @@ abstract class BotPlugin
   override def receive: Receive = uninitialized orElse pluginReceive
 
   private def uninitialized: Receive = {
-    case InitializePlugin(newState, newBrain, newPluginRegistry) =>
-      this.state = newState
+    case InitializePlugin(newBrain, newPluginRegistry) =>
       this.brain = newBrain
       this.pluginRegistry = newPluginRegistry
       this.initialize()

--- a/src/test/scala/com/sumologic/sumobot/plugins/BotPluginTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/plugins/BotPluginTest.scala
@@ -22,9 +22,7 @@ import akka.actor.ActorSystem
 import com.sumologic.sumobot.core.model.IncomingMessage
 import com.sumologic.sumobot.test.annotated.BotPluginTestKit
 import org.scalatest.BeforeAndAfterEach
-import slack.api.RtmConnectState
 import slack.models.{Group, Im, Team, User, Channel => SlackChannel}
-import slack.rtm.RtmState
 
 class BotPluginUT extends BotPlugin {
   override protected def help: String = "help msg"
@@ -33,18 +31,8 @@ class BotPluginUT extends BotPlugin {
       message.respond("Thanks for the message")
   }
 
-  def setState(state: RtmState) = { this.state = state }
 }
 
 class BotPluginTest
   extends BotPluginTestKit(ActorSystem("BotPluginTest")) with BeforeAndAfterEach {
-
-  private val self = User("U123", "bender", None, None, None, None, None, None, None, None, None, None, None, None, None, None)
-  private val somebodyElse = User("U124", "dude", None, None, None, None, None, None, None, None, None, None, None, None, None, None)
-  private val team = Team("T123", "testers", "example.com")
-  private val channel = SlackChannel("C123", "slack_test", 1, Some(self.id), Some(false), Some(true), Some(false), Some(false), None, None, None, None, None, None, None, None, None, None, None, None)
-  private val group = Group("G123", "privatestuff", true, 1, self.id, false, Some(List(self.id, somebodyElse.id)), null, null, None, None, None, None)
-  private val im = Im("I123", true, somebodyElse.id, 1, None)
-  private val startState = RtmConnectState(true, "http://nothing/", self, team)
-  val state = new RtmState(startState)
 }

--- a/src/test/scala/com/sumologic/sumobot/plugins/advice/AdviceTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/plugins/advice/AdviceTest.scala
@@ -26,7 +26,7 @@ import scala.concurrent.duration._
 class AdviceTest extends BotPluginTestKit(ActorSystem("AdviceTest"))  {
 
   val adviceRef = system.actorOf(Props[Advice](), "advice")
-  adviceRef ! InitializePlugin(null, null, null)
+  adviceRef ! InitializePlugin(null, null)
 
   "advice" should {
 

--- a/src/test/scala/com/sumologic/sumobot/plugins/alias/AliasTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/plugins/alias/AliasTest.scala
@@ -33,7 +33,7 @@ class AliasTest
 
   val aliasRef = system.actorOf(Props(classOf[Alias]), "alias")
   val brainRef = system.actorOf(Props(classOf[InMemoryBrain]), "brain")
-  aliasRef ! InitializePlugin(null, brainRef, null)
+  aliasRef ! InitializePlugin(brainRef, null)
 
   "alias" should {
     "allow aliasing messages to the bot" in {

--- a/src/test/scala/com/sumologic/sumobot/plugins/help/HelpTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/plugins/help/HelpTest.scala
@@ -35,7 +35,7 @@ class HelpTest extends BotPluginTestKit(ActorSystem("HelpTest")) {
   reg ! PluginAdded(mock, "mock help")
   reg ! PluginAdded(helpRef, "help help")
 
-  helpRef ! InitializePlugin(null, null, reg)
+  helpRef ! InitializePlugin(null, reg)
 
   val user = mockUser("123", "jshmoe")
 


### PR DESCRIPTION
**What?**
SumoBot Start using EventsAPI as RTM Client is deprecated.

**Why?**
RTM Client is deprecated, classic bots stop working March 31st. New apps don't support RTM Client.
